### PR TITLE
validate v1 schema (and eventually v2)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@
 module.exports = {
   testMatch: [
     '**/tests/*.js'
-  ]
+  ],
+  setupFilesAfterEnv: ['jest-expect-message']
 }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "github-slugger": "^1.2.1",
     "handlebars": "^4.1.2",
     "jest": "^24.8.0",
+    "jest-expect-message": "^1.0.2",
     "make-promises-safe": "^5.0.0",
     "nock": "^10.0.6",
+    "openapi-schema-validator": "^3.0.3",
     "standard": "^13.1.0"
   }
 }

--- a/schemata/v1.yml
+++ b/schemata/v1.yml
@@ -2,12 +2,16 @@ openapi: 3.0.0
 info:
   title: 'Crowdin API v1'
   description: "(Unofficial) OpenAPI schema for the v1 Crowdin API."
+  version: ''
 paths:
   
   '/api/project/{project-identifier}/add-file':
     post:
       summary: 'Add a file to your project.'
       operationId: api.projects.files.add
+      responses:
+        '200':
+          description: 'Added a file to your project.'
   
   '/api/project/{projectIdentifier}/info':
     post:
@@ -22,3 +26,6 @@ paths:
           name: key
           in: query
           required: true
+      responses:
+        '200':
+          description: 'Got project details.'

--- a/tests/schemata.tests.js
+++ b/tests/schemata.tests.js
@@ -1,0 +1,18 @@
+const Validator = require('openapi-schema-validator').default
+const validator = new Validator({ version: 3 })
+const getSchema = require('../lib/get-schema')
+const yaml = require('js-yaml')
+
+describe('schema validation', () => {
+  test('v1', () => {
+    const result = validator.validate(getSchema('v1'))
+    const message = `Errors found in v1 schema:\n\n ${yaml.safeDump(result.errors)}`
+    expect(result.errors.length === 0, message).toBe(true)
+  })
+
+  test.skip('v2', () => {
+    const result = validator.validate(getSchema('v2'))
+    const message = `Errors found in v2 schema:\n\n ${yaml.safeDump(result.errors)}`
+    expect(result.errors.length === 0, message).toBe(true)
+  })
+})


### PR DESCRIPTION
This PR adds a new test file that uses the [openapi-schema-validator](https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-schema-validator) npm module to validate the schema files.

The v1 schema is now valid, but [the v2 schema has a number of issues](https://gist.github.com/zeke/8b6c8cbbe1199ce34d94541e727aad62), so I've skipped that test for now. I opened an issue with Crowdin support to discuss the errors in the current v2 schema.

This is ready for review. We can iterate on the v2 schema and enable that test in a subsequent PR.