### PR TITLE
feat: update repo URL and package package name and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
-# Crowdin API Wrapper
+# Crowdin API Client
 
 A Node.js client for the 
 [v1](https://support.crowdin.com/api/api-integration-setup/) and 
 [v2](https://support.crowdin.com/enterprise/api/) Crowdin APIs
 
+🚧 This client is a work in progress, and not ready for production use. Feel free to try it out and [open issues](https://github.com/crowdin-node/crowdin-node/issues). 🚧
+
 ## Installation
 
-🚧 This is a work in progress. Not ready for general use! 🚧
-
-This module is not yet published to npm. For now, you can install it directly
-form the GitHub repo:
-
 ```sh
-npm install aletrejo/crowdin-wrapper
+npm install crowdin
 ```
 
 ## Basic Usage
 
 ```js
-const crowdin = require('crowdin-wrapper')({
+const crowdin = require('crowdin')({
   key: process.env.CROWDIN_KEY,
   schemaVersion: 'v2'
 })

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ The returned client is an object of deeply nested API operations like
 Each of these operations returns a Promise to a [got](https://ghub.io/got) response object. 
 
 See [docs/v1.md](docs/v1.md) and [docs/v2.md](docs/v2.md) for reference.
+
+## Thanks
+
+Special thanks to :sparkles:[Paul Le Cam](https://www.npmjs.com/~paul_lecam):sparkles: for donation the `crowdin` npm package name. 

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ See [docs/v1.md](docs/v1.md) and [docs/v2.md](docs/v2.md) for reference.
 
 ## Thanks
 
-Special thanks to :sparkles:[Paul Le Cam](https://www.npmjs.com/~paul_lecam):sparkles: for donation the `crowdin` npm package name. 
+Special thanks to :sparkles:[Paul Le Cam](https://www.npmjs.com/~paul_lecam):sparkles: for donating the `crowdin` npm package name. 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "crowdin-wrapper",
-  "version": "1.0.0",
+  "name": "crowdin",
+  "version": "2.0.0",
   "description": "A Node.js client for the v1 and v2 Crowdin APIs",
-  "repository": "https://github.com/aletrejo/crowdin-wrapper",
+  "repository": "https://github.com/crowdin-node/crowdin-node",
   "main": "index.js",
   "scripts": {
     "build": "script/build-docs.js",


### PR DESCRIPTION
This prepares us to move the repo to the @crowdin-node org and publish an initial 2.0.0 version to npm as `crowdin`.

Resolves #6 