### PR TITLE
feat: support directory creation in v1 API

### DIFF
--- a/docs/v1.md
+++ b/docs/v1.md
@@ -3,8 +3,31 @@
 
 ## Operations
 
+- [projects.directories.add(projectIdentifier, [options])](#projects-directories-add)
 - [projects.files.add(projectIdentifier, [options])](#projects-files-add)
 - [projects.getDetails(projectIdentifier, [options])](#projects-get-details)
+
+<a id="projects-directories-add" href="#projects-directories-add">
+  <h2>projects.directories.add(projectIdentifier, [options])</h2>
+</a>
+
+> Add a directory to your project.
+
+**Parameters**
+
+```yml
+- name: projectIdentifier
+  in: path
+  required: true
+- name: key
+  in: query
+  required: true
+- name: name
+  description: Directory name (with path if nested directory should be created).
+  in: query
+  required: true
+
+```
 
 <a id="projects-files-add" href="#projects-files-add">
   <h2>projects.files.add(projectIdentifier, [options])</h2>

--- a/examples/v1-add-files.js
+++ b/examples/v1-add-files.js
@@ -12,11 +12,11 @@ async function main () {
     schemaVersion: 'v1',
     key: CROWDIN_API_KEY
   })
-  
+
   // directory must be created before files can be added.
-  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github'})
-  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github/some-owner'})
-  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github/some-owner/some-repo'})
+  await client.projects.directories.add(CROWDIN_PROJECT_ID, { name: 'github' })
+  await client.projects.directories.add(CROWDIN_PROJECT_ID, { name: 'github/some-owner' })
+  await client.projects.directories.add(CROWDIN_PROJECT_ID, { name: 'github/some-owner/some-repo' })
 
   const addFilesResult = await client.projects.files.add(CROWDIN_PROJECT_ID, {
     files: {
@@ -25,7 +25,7 @@ async function main () {
     }
   })
 
-  // console.log(addFilesResult.body)
+  console.log(addFilesResult.body)
 }
 
 main()

--- a/examples/v1-add-files.js
+++ b/examples/v1-add-files.js
@@ -12,15 +12,20 @@ async function main () {
     schemaVersion: 'v1',
     key: CROWDIN_API_KEY
   })
+  
+  // directory must be created before files can be added.
+  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github'})
+  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github/some-owner'})
+  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github/some-owner/some-repo'})
 
-  const result = await client.projects.files.add(CROWDIN_PROJECT_ID, {
+  const addFilesResult = await client.projects.files.add(CROWDIN_PROJECT_ID, {
     files: {
-      'README.md': 'I am the README.',
-      'config.yml': 'is_yaml: true'
+      'github/some-owner/some-repo/README.md': 'I am the README.',
+      'github/some-owner/some-repo/config.yml': 'is_yaml: true'
     }
   })
 
-  console.log(result.body)
+  // console.log(addFilesResult.body)
 }
 
 main()

--- a/schemata/v1.yml
+++ b/schemata/v1.yml
@@ -4,7 +4,31 @@ info:
   description: "(Unofficial) OpenAPI schema for the v1 Crowdin API."
   version: ''
 paths:
-  
+
+  '/api/project/{projectIdentifier}/add-directory':
+    post:
+      summary: 'Add a directory to your project.' 
+      operationId: api.projects.directories.add
+      externalDocs:
+        url: 'https://support.crowdin.com/api/add-directory/'
+      responses:
+        '200':
+          description: 'Added a directory to your project.'
+      parameters:
+        -
+          name: projectIdentifier
+          in: path
+          required: true
+        -
+          name: key
+          in: query
+          required: true
+        -
+          name: name
+          description: Directory name (with path if nested directory should be created).
+          in: query
+          required: true
+
   '/api/project/{projectIdentifier}/add-file':
     post:
       summary: 'Add files to your project.'


### PR DESCRIPTION
In order to add files in nested directories, those directories must first be created. This PR adds support for the `projects.directories.add()` method. 

Unfortunately you have to call the API for every level, like this:

```js
  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github'})
  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github/some-owner'})
  await client.projects.directories.add(CROWDIN_PROJECT_ID, {name: 'github/some-owner/some-repo'})
```

But that's the way the API works. It would probably be useful at some point to wrap up directory creation and file-adding into a single method, so the user doesn't have to worry about creating directories before adding files.