### PR TITLE
fix: throw error on failed requests

### DIFF
--- a/lib/operate.js
+++ b/lib/operate.js
@@ -37,7 +37,6 @@ module.exports = async function operate (...args) {
       return error.response
     }
 
-    console.error('error making request')
-    console.error(error)
+    throw error
   })
 }


### PR DESCRIPTION
This PR updates the operate function to throw an error instead of logging it to the console. This allows consumers of this client to make their own decisions about how to handle errors.